### PR TITLE
Fix WWW-Authenticate header

### DIFF
--- a/routes-api.php
+++ b/routes-api.php
@@ -166,7 +166,7 @@ function api_user_check_auth() {
         header('Content-Type: text/plain');
         echo 'Authenticated';
     } else {
-        header('WWW-Authenticate: Basic realm="' + config('api_auth_check_realm') + '"');
+        header('WWW-Authenticate: Basic realm="' . config('api_auth_check_realm') . '"');
         http_response_code(401);
     }
 }


### PR DESCRIPTION
WWW-Authenticate header wasn't returned correctly when authentication failed.

If PR is accepted, please merge into release-1.5 and release-1.6 branches.