### PR TITLE
YDA-3792: add options for working with local MTA

### DIFF
--- a/config.php
+++ b/config.php
@@ -40,9 +40,11 @@ config('smtp_host',            '');
 config('smtp_port',           587);
 config('smtp_user',            '');
 config('smtp_password',        '');
-config('smtp_security',     'tls'); // Either 'tls' or 'ssl'.
+config('smtp_auth',          true); // true or false
+config('smtp_security',     'tls'); // 'tls', 'ssl', or false
                                     // Choose 'tls' when the port is 587,
                                     // and 'ssl' when the port is 465.
+                                    // false for plain SMTP (for use with local caching MTA)
 
 // General e-mail customization.
 config('smtp_from_name',       'Yoda External User Service');

--- a/include/mail.php
+++ b/include/mail.php
@@ -9,7 +9,7 @@ function send_mail($to, $subject, $body_plain, $body_html = null) {
 
     $mail->isSMTP();
     $mail->Host       = config('smtp_host');
-    $mail->SMTPAuth   = true;
+    $mail->SMTPAuth   = config('smtp_auth');
     $mail->Username   = config('smtp_user');
     $mail->Password   = config('smtp_password');
     $mail->SMTPSecure = config('smtp_security');


### PR DESCRIPTION
Add config parameter for disabling SMTP encryption for use with
local Postfix MTA, and mention parameter to disable SMTP
authentication.

This PR is part of a set of three PRs, together with https://github.com/UtrechtUniversity/yoda/pull/132 and https://github.com/UtrechtUniversity/yoda-ruleset/pull/178