### PR TITLE
YDA-5505: do not accept backslashes in passwords

### DIFF
--- a/yoda_eus/password_complexity.py
+++ b/yoda_eus/password_complexity.py
@@ -33,4 +33,7 @@ def check_password_complexity(password: str) -> List[str]:
     if not (any(c in string.punctuation for c in password)):
         errors.append("Password needs to contain at least one punctuation character ({})".format(string.punctuation))
 
+    if "\\" in password:
+        errors.append("Password must not contain backslashes.")
+
     return errors

--- a/yoda_eus/templates/web/activate.html
+++ b/yoda_eus/templates/web/activate.html
@@ -111,6 +111,10 @@
      passwordErrors.innerHTML = 'The password needs to contain an uppercase letter, lowercase letter, number and punctuation character.';
      submitButton.disabled = true;
    }
+   else if ( password1Input.value.indexOf('\\') > -1 ) {
+     passwordErrors.innerHTML = 'The password contains a backslash.';
+     submitButton.disabled = true;
+   }
    else if ( password2Input.value.trim().length == 0 ) {
      passwordErrors.innerHTML = 'Please enter the password again.';
      submitButton.disabled = true;

--- a/yoda_eus/templates/web/password-requirements.html
+++ b/yoda_eus/templates/web/password-requirements.html
@@ -1,7 +1,7 @@
                 <p> Your password must meet the following requirements: </p>
                 <ul>
                     <li>It must be between 10 and 1000 characters in length
-                    <li>It must not contain diacritics such as é, ö, and ç
+                    <li>It must not contain diacritics such as é, ö, and ç, or backslashes (&bsol;)
                     <li>At least 1 capital letter A-Z 
                     <li>At least 1 lowercase letter a-z 
                     <li>At least 1 number 0-9 

--- a/yoda_eus/templates/web/reset-password.html
+++ b/yoda_eus/templates/web/reset-password.html
@@ -101,6 +101,10 @@
      passwordErrors.innerHTML = 'The password needs to contain an uppercase letter, lowercase letter, number and punctuation character.';
      submitButton.disabled = true;
    }
+   else if ( password1Input.value.indexOf('\\') > -1) {
+     passwordErrors.innerHTML = 'The password contains a backslash.';
+     submitButton.disabled = true;
+   }
    else if ( password2Input.value.trim().length == 0 ) {
      passwordErrors.innerHTML = 'Please enter the password again.';
      submitButton.disabled = true;

--- a/yoda_eus/tests/test_integration.py
+++ b/yoda_eus/tests/test_integration.py
@@ -184,7 +184,7 @@ class TestMain:
         self._test_activate_and_check_auth(test_client, "Test1!@#$%^&*()", "unactivateduser2", "goodhash2")
 
     def test_activate_and_check_auth_interpunction2(self, test_client):
-        self._test_activate_and_check_auth(test_client, "Test1_-+={}[]\\|", "unactivateduser3", "goodhash3")
+        self._test_activate_and_check_auth(test_client, "Test1_-+={}[]|", "unactivateduser3", "goodhash3")
 
     def test_activate_and_check_auth_interpunction3(self, test_client):
         self._test_activate_and_check_auth(test_client, "Test1;:\"',./<>?", "unactivateduser4", "goodhash4")

--- a/yoda_eus/tests/test_unit.py
+++ b/yoda_eus/tests/test_unit.py
@@ -41,6 +41,10 @@ class TestMain:
         result = check_password_complexity("Test123456789")
         assert result == ["Password needs to contain at least one punctuation character ({})".format(string.punctuation)]
 
+    def test_password_validation_backslash(self):
+        result = check_password_complexity("Test\\123456789!")
+        assert result == ["Password must not contain backslashes."]
+
     def test_password_validation_multiple(self):
         result = check_password_complexity("Test")
         assert len(result) == 3


### PR DESCRIPTION
These don't get passed correctly to the external-auth script on the provider, and therefore cause authentication to fail.