### PR TITLE
YDA-5548: limit image builds to main repo

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   push-image:
+    if: github.repository == 'utrechtuniversity/yoda-external-user-service'
     runs-on: ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
Only build and push images when running on the main repo (not on forks)