### PR TITLE
YDA-7045: HTML escape data in HTML emails

### DIFF
--- a/yoda_eus/mail.py
+++ b/yoda_eus/mail.py
@@ -76,18 +76,44 @@ def send_email_template(app, to, subject, template_name, template_data):
     template_path = os.path.join(app.config.get("MAIL_TEMPLATE_DIR"),
                                  app.config.get("MAIL_TEMPLATE"))
 
+    plain_body = _get_plain_body(template_path, template_name, template_data)
+    html_body = _get_html_body(template_path, template_name, template_data)
+
+    send_email(app, to, subject, plain_body, html_body)
+
+
+def _get_plain_body(template_path, template_name, template_data):
+    """Compiles the plain text body of an email based on a template
+       and template data
+
+    :param template_path:      Path where the templates can be found
+    :param template_name:      Name of the template in the template directory to use, excluding extensions
+    :param template_data:      Variables to interpolate, as a dictionary
+
+    :returns:                  Plain text body for email
+    """
     text_template = Path(os.path.join(template_path, template_name + ".txt.j2")).read_text()
+    plain_body_template = Environment(loader=BaseLoader).from_string(text_template)
+    return plain_body_template.render(**template_data)
+
+
+def _get_html_body(template_path, template_name, template_data):
+    """Compiles the HTML body of an email based on a template
+       and template data
+
+    :param template_path:      Path where the templates can be found
+    :param template_name:      Name of the template in the template directory to use, excluding extensions
+    :param template_data:      Variables to interpolate, as a dictionary
+
+    :returns:                  Plain text body for email
+    """
     html_main_template = Path(os.path.join(template_path, template_name + ".html.j2")).read_text()
     html_header_template = Path(os.path.join(template_path, "common-start.html.j2")).read_text()
     html_footer_template = Path(os.path.join(template_path, "common-end.html.j2")).read_text()
     html_full_template = html_header_template + html_main_template + html_footer_template
 
-    plain_body_template = Environment(loader=BaseLoader).from_string(text_template)
-    plain_body = plain_body_template.render(**template_data)
-    html_body_template = Environment(loader=BaseLoader).from_string(html_full_template)
-    html_body = html_body_template.render(**template_data)
-
-    send_email(app, to, subject, plain_body, html_body)
+    html_body_template = Environment(loader=BaseLoader, autoescape=True).from_string(html_full_template)
+    return html_body_template.render(**template_data)
 
 
 def send_email(app, to, subject, plain_body, html_body):

--- a/yoda_eus/tests/test_unit.py
+++ b/yoda_eus/tests/test_unit.py
@@ -1,10 +1,10 @@
-__copyright__ = 'Copyright (c) 2023, Utrecht University'
-__license__   = 'GPLv3, see LICENSE'
+__copyright__ = 'Copyright (c) 2023-2026, Utrecht University'
+__license__  = 'GPLv3, see LICENSE'
 
 import string
 from unittest.mock import patch
 
-from yoda_eus.mail import is_email_valid
+from yoda_eus.mail import _get_html_body, _get_plain_body, is_email_valid
 from yoda_eus.password_complexity import check_password_complexity
 from yoda_eus.util import get_validated_static_path
 
@@ -140,3 +140,124 @@ class TestMain:
             )
             is None
         )
+
+    def test_plain_body_email(self):
+        template_parameters = {"USERNAME": "user",
+                               "CREATOR": "creator",
+                               "HASH_URL": "https://hashurl"}
+        expected_body = """Hello user,
+
+A Yoda account has been created for you by creator.
+Please contact this person in case it is unclear why
+you have received this invitation.
+
+Yoda is a research data management system.
+You can activate your account by visiting the following webpage:
+
+https://hashurl
+
+More information on Yoda can be found at https://www.uu.nl/yoda
+
+Kind regards,
+
+The Yoda External User Service"""
+
+        assert (_get_plain_body("templates/mail/uu",
+                                "invitation",
+                                template_parameters)
+                == expected_body)
+
+    def test_html_body_email(self):
+        template_parameters = {"USERNAME": "user",
+                               "CREATOR": "creator",
+                               "HASH_URL": "https://hashurl"}
+        expected_body = """<!DOCTYPE html>
+<html>
+    <head>
+        <title></title>
+        <meta charset="utf-8">
+    </head>
+    <body>
+<p>
+Hello user,
+</p>
+
+<p>
+A Yoda account has been created for you by creator.
+Please contact this person in case it is unclear why
+you have received this invitation.
+</p>
+
+<p>
+Yoda is a research data management system.
+You can activate your account by visiting the following webpage:
+</p>
+
+<a href="https://hashurl">https://hashurl</a>
+
+<p>
+More information on Yoda can be found 
+at <a href="https://www.uu.nl/yoda">https://www.uu.nl/yoda</a>
+</p>
+
+<p>
+Kind regards,
+</p>
+
+<p>
+The Yoda External User Service
+</p>
+    </body>
+</html>"""  # noqa W291
+        assert (_get_html_body("templates/mail/uu",
+                               "invitation",
+                               template_parameters)
+                == expected_body)
+
+    def test_html_body_email_escape_text(self):
+        # Ensure that we are preventing HTML injection in HTML templates
+        template_parameters = {"USERNAME": "user",
+                               "CREATOR": "<script>alert( 'Creator!');</script>",
+                               "HASH_URL": "https://hashurl"}
+        expected_body = """<!DOCTYPE html>
+<html>
+    <head>
+        <title></title>
+        <meta charset="utf-8">
+    </head>
+    <body>
+<p>
+Hello user,
+</p>
+
+<p>
+A Yoda account has been created for you by &lt;script&gt;alert( &#39;Creator!&#39;);&lt;/script&gt;.
+Please contact this person in case it is unclear why
+you have received this invitation.
+</p>
+
+<p>
+Yoda is a research data management system.
+You can activate your account by visiting the following webpage:
+</p>
+
+<a href="https://hashurl">https://hashurl</a>
+
+<p>
+More information on Yoda can be found 
+at <a href="https://www.uu.nl/yoda">https://www.uu.nl/yoda</a>
+</p>
+
+<p>
+Kind regards,
+</p>
+
+<p>
+The Yoda External User Service
+</p>
+    </body>
+</html>"""  # noqa W291
+        assert (_get_html_body("templates/mail/uu",
+                               "invitation",
+                               template_parameters)
+                == expected_body)


### PR DESCRIPTION
Automatically escape HTML in any data that is passed to HTML mail templates, in order to prevent HTML injection risks.